### PR TITLE
Strip wrapper exceptions

### DIFF
--- a/src/MonoTouch.Fabric.Crashlytics/DefaultCrashlyticsManager.cs
+++ b/src/MonoTouch.Fabric.Crashlytics/DefaultCrashlyticsManager.cs
@@ -20,14 +20,23 @@ namespace MonoTouch.Fabric.Crashlytics
             CatchUnhandledExceptions = true;
             CatchUnobservedTaskExceptions = true;
             RethrowException = false;
+            StripWrapperExceptions = false;
         }
 
         public override void OnExceptionCaught(Exception ex)
         {
-            foreach (var underlyingException in GetUnderlyingExceptions(ex))
+            if (StripWrapperExceptions)
             {
-                CaptureManagedInfo(underlyingException);
-                CaptureStackFrames(underlyingException);
+                foreach (var underlyingException in GetUnderlyingExceptions(ex))
+                {
+                    CaptureManagedInfo(underlyingException);
+                    CaptureStackFrames(underlyingException);
+                }
+            }
+            else
+            {
+                CaptureManagedInfo(ex);
+                CaptureStackFrames(ex);
             }
 
             if (RethrowException)
@@ -36,6 +45,7 @@ namespace MonoTouch.Fabric.Crashlytics
 
         public override NSObject SharedInstance { get { return Crashlytics.SharedInstance; } }
         public bool RethrowException { get; set; }
+        public bool StripWrapperExceptions { get; set; }
 
         protected virtual void CaptureManagedInfo(Exception ex)
         {

--- a/src/MonoTouch.Fabric.Crashlytics/DefaultCrashlyticsManager.cs
+++ b/src/MonoTouch.Fabric.Crashlytics/DefaultCrashlyticsManager.cs
@@ -24,8 +24,11 @@ namespace MonoTouch.Fabric.Crashlytics
 
         public override void OnExceptionCaught(Exception ex)
         {
-            CaptureManagedInfo(ex);
-            CaptureStackFrames(ex);
+            foreach (var underlyingException in GetUnderlyingExceptions(ex))
+            {
+                CaptureManagedInfo(underlyingException);
+                CaptureStackFrames(underlyingException);
+            }
 
             if (RethrowException)
                 RaiseNativeException(ex);
@@ -96,6 +99,40 @@ namespace MonoTouch.Fabric.Crashlytics
                 frameWalker(new StackTrace(ex, true));
         
                 Crashlytics.SharedInstance.RecordCustomExceptionName(ex.GetType().Name, ex.Message, frames.Cast<NSObject>().ToArray());
+            }
+        }
+
+        protected virtual IEnumerable<Exception> GetUnderlyingExceptions(Exception ex)
+        {
+            if (ex == null)
+                yield break;
+
+            var aggregateException = ex as AggregateException;
+            if (aggregateException != null)
+            {
+                if (aggregateException.InnerExceptions.Count > 0)
+                {
+                    foreach (var innerException in aggregateException.Flatten().InnerExceptions)
+                        foreach (var underlyingException in GetUnderlyingExceptions(innerException))
+                            yield return underlyingException;
+                }
+                else
+                {
+                    yield return aggregateException;
+                }
+            }
+            else
+            {
+                var targetInvocationException = ex as TargetInvocationException;
+                if (targetInvocationException != null && targetInvocationException.InnerException != null)
+                {
+                    foreach (var underlyingException in GetUnderlyingExceptions(targetInvocationException.InnerException))
+                        yield return underlyingException;
+                }
+                else
+                {
+                    yield return ex;
+                }
             }
         }
 

--- a/src/MonoTouch.Fabric.Crashlytics/Setup.cs
+++ b/src/MonoTouch.Fabric.Crashlytics/Setup.cs
@@ -127,39 +127,39 @@ namespace MonoTouch.Fabric.Crashlytics
 			}
 		}
 
-        public static IEnumerable<Exception> GetUnderlyingExceptions(Exception ex)
-        {
-            if (ex == null)
-                yield break;
+		public static IEnumerable<Exception> GetUnderlyingExceptions(Exception ex)
+		{
+			if (ex == null)
+				yield break;
 
-            var aggregateException = ex as AggregateException;
-            if (aggregateException != null)
-            {
-                if (aggregateException.InnerExceptions.Count > 0)
-                {
-                    foreach (var innerException in aggregateException.Flatten().InnerExceptions)
-                        foreach (var underlyingException in GetUnderlyingExceptions(innerException))
-                            yield return underlyingException;
-                }
-                else
-                {
-                    yield return aggregateException;
-                }
-            }
-            else
-            {
-                var targetInvocationException = ex as TargetInvocationException;
-                if (targetInvocationException != null && targetInvocationException.InnerException != null)
-                {
-                    foreach (var underlyingException in GetUnderlyingExceptions(targetInvocationException.InnerException))
-                        yield return underlyingException;
-                }
-                else
-                {
-                    yield return ex;
-                }
-            }
-        }
+			var aggregateException = ex as AggregateException;
+			if (aggregateException != null)
+			{
+				if (aggregateException.InnerExceptions.Count > 0)
+				{
+					foreach (var innerException in aggregateException.Flatten().InnerExceptions)
+						foreach (var underlyingException in GetUnderlyingExceptions(innerException))
+							yield return underlyingException;
+				}
+				else
+				{
+					yield return aggregateException;
+				}
+			}
+			else
+			{
+				var targetInvocationException = ex as TargetInvocationException;
+				if (targetInvocationException != null && targetInvocationException.InnerException != null)
+				{
+					foreach (var underlyingException in GetUnderlyingExceptions(targetInvocationException.InnerException))
+						yield return underlyingException;
+				}
+				else
+				{
+					yield return ex;
+				}
+			}
+		}
 
 		private static void ConvertToNativeExceptionAndRaise(object e)
 		{


### PR DESCRIPTION
As discussed in issue #9, when an AggregateException or TargetInvocationException is thrown, the exception is logged as-is to Crashlytics. The real underlying cause of the exception, however, is lost because the inner exception(s) are not logged.

This PR adds the ability to strip such exceptions so that the inner exceptions can instead be logged.

For the "legacy" way of initializing Crashlytics, the consuming application code would need to look as follows (note the foreach loop as there may be several exceptions returned from an AggregateException):
```
Setup.EnableCrashReporting(() =>
{
    var crashlytics = Crashlytics.SharedInstance;
    crashlytics.DebugMode = true;
    Crashlytics.StartWithAPIKey("replace_with_your_crashlytics_api_key");

    Fabric.With(new NSObject[]{ crashlytics });

    AppDomain.CurrentDomain.UnhandledException += (sender, e) =>
    {
        foreach (var ex in Setup.GetUnderlyingExceptions(e.ExceptionObject as Exception))
        {
            Setup.CaptureManagedInfo(ex);
            Setup.CaptureStackFrames(ex);
        }
        Setup.ThrowExceptionAsNative(e.ExceptionObject);
    };

    TaskScheduler.UnobservedTaskException += (sender, e) =>
    {
        foreach (var ex in Setup.GetUnderlyingExceptions(e.Exception))
        {
            Setup.CaptureManagedInfo(ex);
            Setup.CaptureStackFrames(ex);
        }
        Setup.ThrowExceptionAsNative(e.Exception);
    };
}, Path.GetFileNameWithoutExtension(typeof(AppDelegate).Module.Name));
```

For the new way, there is a flag called **StripWrapperExceptions** on the **DefaultCrashlyticsManager** which is false by default. To opt-in for stripping of the above exceptions, one would set the flag to true.

Please let me know your thoughts?